### PR TITLE
Remove crypto class mapping on index

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,5 @@ module.exports = {
   types: require('./types'),
   utils: require('./utils'),
   errors: require('./errors'),
-  validate: require('./validate'),
-  crypto: require('./crypto')
+  validate: require('./validate')
 };


### PR DESCRIPTION
Due to deletion of crypto classs, we have to remove the mapping from index.js.